### PR TITLE
fix: update feedback button to point to correct repository

### DIFF
--- a/src/components/FeedbackWidget.js
+++ b/src/components/FeedbackWidget.js
@@ -15,7 +15,7 @@ export default function FeedbackWidget() {
   }
 
   const handleFeedbackClick = () => {
-    const issueUrl = 'https://github.com/openmobilehub/developer-multipaz-website/issues/new';
+    const issueUrl = 'https://github.com/openwallet-foundation/multipaz-developer-website/issues/new';
     const template = 'website-feedback.md';
     
     // Get the current page title


### PR DESCRIPTION
- Change from openmobilehub to openwallet-foundation
- Ensures feedback issues are created in the right repo

addrsses [#1258](https://github.com/openwallet-foundation/multipaz/issues/1258) - GitHub issues creation from the website feedback button
