### PR TITLE
Update repository reference in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout Kotlin Repository
         uses: actions/checkout@v4
         with:
-          repository: VishnuSanal/multipaz-identity-credential
+          repository: openwallet-foundation/multipaz
           path: kotlin-repo
           ref: 'main'
           fetch-depth: 0


### PR DESCRIPTION
fix the repo link to point to openwallet-foundation/multipas in Trigger Docs Update