### PR TITLE
update docs workflow after dokka migration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.cache-kdocs.outputs.cache-hit != 'true'
         run: |
           cd kotlin-repo
-          ./gradlew dokkaHtmlMultiModule
+          ./gradlew dokkaGenerate
           echo "KDocs generated successfully"
           
       - name: Setup Node.js

--- a/copy_docs.sh
+++ b/copy_docs.sh
@@ -1,13 +1,13 @@
 KOTLIN_REPO="kotlin-repo"
 DOCUSAURUS_REPO="docusaurus-repo"
 
-cp -R $KOTLIN_REPO/build/dokka/htmlMultiModule/* $DOCUSAURUS_REPO/static/kdocs/
+cp -R $KOTLIN_REPO/build/dokka/html/* $DOCUSAURUS_REPO/static/kdocs/
 echo "KDocs copied to Docusaurus static/api directory"
 
 cp $KOTLIN_REPO/CHANGELOG.md                $DOCUSAURUS_REPO/changelog/0-changelog.md
 
-cp $KOTLIN_REPO/docs/contributing.md        $DOCUSAURUS_REPO/contributing/0-contributing.md
-cp $KOTLIN_REPO/docs/code-of-conduct.md     $DOCUSAURUS_REPO/contributing/1-code-of-conduct.md
+cp $KOTLIN_REPO/CONTRIBUTING.md             $DOCUSAURUS_REPO/contributing/0-contributing.md
+cp $KOTLIN_REPO/CODE-OF-CONDUCT.md          $DOCUSAURUS_REPO/contributing/1-code-of-conduct.md
 cp $KOTLIN_REPO/CODING-STYLE.md             $DOCUSAURUS_REPO/contributing/2-coding-style.md
 cp $KOTLIN_REPO/DEVELOPER-ENVIRONMENT.md    $DOCUSAURUS_REPO/contributing/3-developer-environment.md
 cp $KOTLIN_REPO/TESTING.md                  $DOCUSAURUS_REPO/contributing/4-testing.md


### PR DESCRIPTION
## Related Issues

update to reflect the changes from https://github.com/openwallet-foundation/multipaz/pull/1531

addresses issue: https://github.com/openwallet-foundation/multipaz/issues/1229

## Description

update the KDOCS docs generation workflow after dokka deps migration to v2.1.0

## Type of Change

- [ ] 📝 Documentation update (guides, tutorials, API docs)
- [ ] 🎨 UI/UX improvements
- [ ] ✨ New content (blog post, codelab, Get started page)
- [ ] 🐛 Bug fix (typo, broken link, layout issue)
- [x] ⚙️ Configuration change (build, CI/CD, deployment)
- [ ] 🔧 Code change
- [x] 🧹 Maintenance (dependencies, refactoring, cleanup)

## GitHub Pages Link

https://vishnusanal.github.io/multipaz-developer-website/kdocs/index.html

## Screenshots/Videos

## Testing Checklist

- [x] Local development build (`npm start`) works correctly
- [x] Production build (`npm run build`) completes successfully
- [x] All links are working and not broken
- [x] Content is accurate and properly formatted
- [x] Navigation works as expected