### PR TITLE
Fix doc link slugs and restore scroll on navigation

### DIFF
--- a/api/build-docs-context.js
+++ b/api/build-docs-context.js
@@ -67,8 +67,14 @@ async function buildContext() {
     const files = collectMarkdownFiles(dir);
     for (const file of files) {
       const relativePath = path.relative(rootDir, file);
+      // Strip ordering prefixes from filenames (e.g. "01-storage.md" -> "storage.md")
+      // so the AI references actual Docusaurus URL slugs. Only targets short
+      // numeric prefixes (1-3 digits) on the basename to avoid mangling dates.
+      const dir = path.dirname(relativePath);
+      const base = path.basename(relativePath).replace(/^\d{1,3}-/, '');
+      const slugPath = path.join(dir, base);
       const content = fs.readFileSync(file, 'utf-8');
-      context += `\n--- ${relativePath} ---\n${content}\n`;
+      context += `\n--- ${slugPath} ---\n${content}\n`;
     }
   }
 

--- a/src/components/AskAIWidget.js
+++ b/src/components/AskAIWidget.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import Markdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneLight, oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
@@ -93,6 +93,16 @@ export default function AskAIWidget() {
   const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef(null);
   const inputRef = useRef(null);
+
+  const mountedRef = useRef(false);
+  // Callback ref: scrolls to bottom when the sentinel div first mounts (page refresh, navigation back)
+  const scrollSentinelRef = useCallback((node) => {
+    messagesEndRef.current = node;
+    if (node && !mountedRef.current) {
+      mountedRef.current = true;
+      node.scrollIntoView({ behavior: 'instant' });
+    }
+  }, []);
 
   useEffect(() => {
     sessionStorage.setItem('askAiMessages', JSON.stringify(messages));
@@ -251,7 +261,7 @@ export default function AskAIWidget() {
                 </div>
               </div>
             )}
-            <div ref={messagesEndRef} />
+            <div ref={scrollSentinelRef} />
           </div>
 
           <form className={styles.chatInputForm} onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- Strip numeric prefixes (e.g. `01-storage` → `storage`) from file paths in the docs context so the AI generates correct Docusaurus URL slugs
- Restore chat scroll position when the widget re-mounts after page refresh or external navigation (e.g. clicking a GitHub link and returning)

## Test plan
- [ ] Ask "How do I set up storage?" and verify the link points to `/docs/getting-started/holder/storage` (not `/docs/getting-started/holder/01-storage`)
- [ ] Open the widget, have a conversation, navigate to an external link, come back — chat should scroll to the bottom
- [ ] Refresh the page with the widget open — chat should scroll to the bottom

Signed-off-by: Diego Zuluaga <dfzuluaga@gmail.com>