### PR TITLE
Add BUILD_KDOCS flag to skip Dokka generation for faster CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      build_kdocs:
+        description: 'Generate API reference KDocs with Dokka (disable for faster CI)'
+        type: boolean
+        default: true
   repository_dispatch:
     types: [multipaz-repo-updated, extras-repo-updated]
 
@@ -21,6 +26,17 @@ jobs:
   build:
     name: Build Docusaurus with KDocs
     runs-on: ubuntu-latest
+    env:
+      # Whether to build the API reference KDocs ('true') or skip the slow Dokka
+      # generation ('false').
+      #   - On a manual run, the "build_kdocs" checkbox is authoritative and overrides
+      #     everything else (tick to build, untick to skip).
+      #   - On automatic runs (push / repository_dispatch), KDocs are built unless the
+      #     repository variable BUILD_KDOCS is set to 'false' (e.g. on a fork) to
+      #     permanently skip them.
+      # build_kdocs is a boolean input, so it's matched against both the boolean and
+      # string forms to stay robust regardless of how the value is rendered.
+      BUILD_KDOCS: ${{ github.event_name == 'workflow_dispatch' && ((inputs.build_kdocs == true || inputs.build_kdocs == 'true') && 'true' || 'false') || (vars.BUILD_KDOCS == 'false' && 'false' || 'true') }}
     steps:
       - name: Checkout Docusaurus Repository
         uses: actions/checkout@v4
@@ -38,6 +54,7 @@ jobs:
 
       - name: Get Multipaz Repo Commit Hash
         id: multipaz-commit-hash
+        if: env.BUILD_KDOCS == 'true'
         run: |
           cd multipaz-repo
           COMMIT_HASH=$(git rev-parse HEAD)
@@ -46,12 +63,14 @@ jobs:
 
       - name: Cache Multipaz KDocs
         id: cache-multipaz-kdocs
+        if: env.BUILD_KDOCS == 'true'
         uses: actions/cache@v3
         with:
           path: multipaz-repo/build/dokka
           key: kdocs-${{ steps.multipaz-commit-hash.outputs.commit_hash }}
 
       - name: Checkout Multipaz Extras Repository
+        if: env.BUILD_KDOCS == 'true'
         uses: actions/checkout@v4
         with:
           repository: openwallet-foundation/multipaz-extras
@@ -62,6 +81,7 @@ jobs:
 
       - name: Get Extras Repo Commit Hash
         id: extras-commit-hash
+        if: env.BUILD_KDOCS == 'true'
         run: |
           cd extras-repo
           COMMIT_HASH=$(git rev-parse HEAD)
@@ -70,12 +90,14 @@ jobs:
 
       - name: Cache Extras KDocs
         id: cache-extras-kdocs
+        if: env.BUILD_KDOCS == 'true'
         uses: actions/cache@v3
         with:
           path: extras-repo/build/dokka
           key: kdocs-${{ steps.extras-commit-hash.outputs.commit_hash }}
 
       - name: Set up JDK
+        if: env.BUILD_KDOCS == 'true'
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -83,14 +105,14 @@ jobs:
           cache: 'gradle'
 
       - name: Generate Multipaz KDocs with Dokka
-        if: steps.cache-multipaz-kdocs.outputs.cache-hit != 'true'
+        if: env.BUILD_KDOCS == 'true' && steps.cache-multipaz-kdocs.outputs.cache-hit != 'true'
         run: |
           cd multipaz-repo
           ./gradlew dokkaGenerate
           echo "KDocs generated successfully"
 
       - name: Generate Extras KDocs with Dokka
-        if: steps.cache-extras-kdocs.outputs.cache-hit != 'true'
+        if: env.BUILD_KDOCS == 'true' && steps.cache-extras-kdocs.outputs.cache-hit != 'true'
         run: |
           cd extras-repo
           ./gradlew dokkaGenerate
@@ -104,6 +126,7 @@ jobs:
           cache-dependency-path: docusaurus-repo/package-lock.json
 
       - name: Create API directories in Docusaurus static folder
+        if: env.BUILD_KDOCS == 'true'
         run: |
           mkdir -p docusaurus-repo/static/kdocs
           mkdir -p docusaurus-repo/static/kdocs-extras

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ To include a new **file from the multipaz repo**, add its path to the `MULTIPAZ_
 | Variable | Description |
 |---|---|
 | `ASK_AI_API_URL` | URL of the deployed Ask AI API (e.g., your Vercel deployment URL) |
+| `WEBSITE_ENVIRONMENT` | `PRODUCTION` to serve at `/` (custom domain), `DEVELOPMENT` to serve at `/{repo-name}/` |
+| `BUILD_KDOCS` | Set to `false` to skip API reference KDoc generation for faster builds (see [Skipping KDoc Generation](#skipping-kdoc-generation-faster-builds)). Optional; defaults to building KDocs |
 
 ### Deploying the API server to Vercel
 
@@ -192,6 +194,26 @@ GitHub Actions Setup
 
 1. In Multipaz Repository => [.github/workflows/trigger-docusaurus-update.yml](https://github.com/openwallet-foundation/multipaz/blob/main/.github/workflows/trigger-docusaurus-update.yml)
 2. In Multipaz Developer Website Repository => [.github/workflows/docs.yml](https://github.com/openwallet-foundation/multipaz-developer-website/blob/main/.github/workflows/docs.yml)
+
+### Skipping KDoc Generation (faster builds)
+
+Generating the API reference KDocs (`./gradlew dokkaGenerate` for both the
+`multipaz` and `multipaz-extras` repos) is by far the slowest part of the build.
+The `BUILD_KDOCS` flag lets you skip it — useful for forks and quick test
+deployments that don't need the API reference. When skipped, the site still
+builds and deploys; only the `/kdocs` and `/kdocs-extras` API reference pages are
+omitted (links into them will 404 on that deployment).
+
+There are two ways to control it:
+
+| How | Scope | Effect |
+|---|---|---|
+| **`build_kdocs` checkbox** on the manual *Run workflow* dialog (Actions → Build and Deploy Docusaurus with KDocs → Run workflow) | A single manual run | Tick to build, untick to skip. **Overrides the repository variable.** |
+| **`BUILD_KDOCS` repository variable** (Settings → Secrets and variables → Actions → **Variables** → New repository variable) | All automatic runs (push / `repository_dispatch`) | Set to `false` to permanently skip KDoc generation. Any other value (or unset) builds them. |
+
+`BUILD_KDOCS` is a repository **variable**, not a secret — no secret needs to be
+configured for this. The checkbox is authoritative on manual runs; the variable
+only governs automatic runs.
 
 ### Required Repository Settings
 

--- a/copy_docs.sh
+++ b/copy_docs.sh
@@ -2,11 +2,25 @@ MULTIPAZ_REPO="multipaz-repo"
 EXTRAS_REPO="extras-repo"
 DOCUSAURUS_REPO="docusaurus-repo"
 
-cp -R $MULTIPAZ_REPO/build/dokka/html/* $DOCUSAURUS_REPO/static/kdocs/
-echo "Multipaz KDocs copied to Docusaurus kdocs/ directory"
+# KDoc copying is gated on BUILD_KDOCS (set by CI). When CI disables
+# KDoc generation for faster builds, the copy is skipped entirely.
+if [ "$BUILD_KDOCS" != "false" ]; then
+  if [ ! -d "$MULTIPAZ_REPO/build/dokka/html" ]; then
+    echo "ERROR: Multipaz KDocs not found at $MULTIPAZ_REPO/build/dokka/html" >&2
+    exit 1
+  fi
+  cp -R $MULTIPAZ_REPO/build/dokka/html/* $DOCUSAURUS_REPO/static/kdocs/
+  echo "Multipaz KDocs copied to Docusaurus kdocs/ directory"
 
-cp -R $EXTRAS_REPO/build/dokka/html/* $DOCUSAURUS_REPO/static/kdocs-extras/
-echo "Multipaz Extras KDocs copied to Docusaurus kdocs-extras/ directory"
+  if [ ! -d "$EXTRAS_REPO/build/dokka/html" ]; then
+    echo "ERROR: Multipaz Extras KDocs not found at $EXTRAS_REPO/build/dokka/html" >&2
+    exit 1
+  fi
+  cp -R $EXTRAS_REPO/build/dokka/html/* $DOCUSAURUS_REPO/static/kdocs-extras/
+  echo "Multipaz Extras KDocs copied to Docusaurus kdocs-extras/ directory"
+else
+  echo "Skipping KDocs copy (BUILD_KDOCS=false)"
+fi
 
 cp $MULTIPAZ_REPO/CHANGELOG.md                $DOCUSAURUS_REPO/changelog/0-changelog.md
 


### PR DESCRIPTION
## Related Issues
fixes https://github.com/openwallet-foundation/multipaz-developer-website/issues/78

## Description

KDoc generation (./gradlew dokkaGenerate for both multipaz and
multipaz-extras) is the slowest part of the docs build. Gate it behind a
BUILD_KDOCS flag so forks and quick deploys can skip it:

- workflow_dispatch gains a "build_kdocs" checkbox that is authoritative
  on manual runs (overrides the repo variable).
- On automatic runs (push / repository_dispatch), KDocs build unless the
  repository variable BUILD_KDOCS is set to 'false'.
- copy_docs.sh skips the KDoc copy when disabled, and hard-fails (exit 1)
  if KDocs are required but missing instead of silently shipping without
  API docs.
- also adds the relevant docs to README

## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] 📝 Documentation update (guides, tutorials, API docs)
- [ ] 🎨 UI/UX improvements
- [ ] ✨ New content (blog post, codelab, Get started page)
- [ ] 🐛 Bug fix (typo, broken link, layout issue)
- [x] ⚙️ Configuration change (build, CI/CD, deployment)
- [ ] 🔧 Code change
- [ ] 🧹 Maintenance (dependencies, refactoring, cleanup)

## GitHub Pages Link
https://vishnusanal.github.io/multipaz-developer-website/

workflow run: https://github.com/VishnuSanal/multipaz-developer-website/actions/runs/27606405266

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate UI/UX changes -->

## Testing Checklist
<!-- Verify that the following have been tested -->

- [x] Local development build (`npm start`) works correctly
- [x] Production build (`npm run build`) completes successfully
- [x] All links are working and not broken
- [x] Content is accurate and properly formatted
- [x] Navigation works as expected